### PR TITLE
Add Gemini API integration as OpenAI alternative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.787.0",
         "@aws-sdk/s3-request-presigner": "^3.787.0",
+        "@google/genai": "^1.9.0",
         "@react-navigation/native-stack": "^7.3.10",
         "@react-navigation/stack": "^7.2.10",
         "@supabase/supabase-js": "^2.49.4",
@@ -1581,6 +1582,27 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
+      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.14.2",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -3698,6 +3720,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -3822,6 +3853,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4442,6 +4479,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4711,6 +4757,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -4986,6 +5038,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5136,6 +5231,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5154,6 +5275,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5513,6 +5647,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5800,6 +5946,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5824,6 +5979,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/leven": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.787.0",
     "@aws-sdk/s3-request-presigner": "^3.787.0",
+    "@google/genai": "^1.9.0",
     "@react-navigation/native-stack": "^7.3.10",
     "@react-navigation/stack": "^7.2.10",
     "@supabase/supabase-js": "^2.49.4",

--- a/server/src/gemini-service.ts
+++ b/server/src/gemini-service.ts
@@ -1,0 +1,100 @@
+import { GoogleGenAI } from "@google/genai";
+
+const geminiApiKey = process.env.GEMINI_API_KEY;
+
+if (!geminiApiKey) {
+    console.warn("GEMINI_API_KEY environment variable is not set. Gemini service will not be available.");
+}
+
+const ai = geminiApiKey ? new GoogleGenAI({ apiKey: geminiApiKey }) : null;
+
+export interface GeminiTranscriptionOptions {
+    model?: string;
+    prompt?: string;
+}
+
+export interface GeminiChatOptions {
+    model?: string;
+    systemPrompt?: string;
+    temperature?: number;
+}
+
+/**
+ * Transcribe audio using Gemini API (placeholder - Gemini doesn't have direct audio transcription)
+ * This would need to be implemented with a different approach or service
+ */
+export async function transcribeWithGemini(audioPath: string, options: GeminiTranscriptionOptions = {}): Promise<any> {
+    throw new Error("Gemini API does not support direct audio transcription. Use OpenAI Whisper or other transcription service.");
+}
+
+/**
+ * Generate daily report using Gemini API
+ */
+export async function generateReportWithGemini(
+    transcription: any,
+    systemPrompt: string,
+    reportSchema: any,
+    options: GeminiChatOptions = {}
+): Promise<any> {
+    if (!ai) {
+        throw new Error("Gemini API is not configured. Please set GEMINI_API_KEY environment variable.");
+    }
+
+    const model = options.model || "gemini-2.5-flash";
+    
+    try {
+        // Prepare the timed transcript format for Gemini
+        const timedTranscript = transcription.words 
+            ? transcription.words.map((w: any) => `[${w.start.toFixed(2)}] ${w.word}`).join(' ')
+            : transcription.text;
+
+        const prompt = `${systemPrompt}
+
+Here is the timed transcript of a video walkthrough:
+
+---
+${timedTranscript}
+---
+
+Please generate a daily report in JSON based *only* on the content of this transcript and adhering strictly to the following JSON schema. Never mention the transcript or video walkthrough directly. Your report is to be as though it was written by the person doing the walkthrough.:
+
+${JSON.stringify(reportSchema, null, 2)}`;
+
+        console.log(`Using Gemini model: ${model}`);
+        
+        const response = await ai.models.generateContent({
+            model: model,
+            contents: prompt
+        });
+
+        if (!response.text) {
+            throw new Error("No response text received from Gemini API");
+        }
+
+        // Try to extract JSON from the response
+        let reportJson;
+        try {
+            // Gemini might wrap JSON in markdown code blocks
+            const jsonMatch = response.text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+            const jsonText = jsonMatch ? jsonMatch[1] : response.text;
+            reportJson = JSON.parse(jsonText);
+        } catch (parseError) {
+            console.error("Failed to parse Gemini response as JSON:", parseError);
+            console.error("Raw response:", response.text);
+            throw new Error("Gemini response could not be parsed as valid JSON");
+        }
+
+        return reportJson;
+
+    } catch (error: any) {
+        console.error("Error generating report with Gemini:", error);
+        throw new Error(`Gemini API error: ${error.message}`);
+    }
+}
+
+/**
+ * Check if Gemini API is available
+ */
+export function isGeminiAvailable(): boolean {
+    return ai !== null;
+}

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -39,12 +39,13 @@ router.get('/master-config', protect, async (req: Request, res: Response) => {
 router.put('/master-config', protect, async (req: Request, res: Response) => {
   if (!(await requireDev(req, res))) return;
   // Acceptable fields
-  const { config_chat_model, config_whisper_model, config_system_prompt, config_report_json_schema } = req.body;
+  const { config_chat_model, config_whisper_model, config_system_prompt, config_report_json_schema, use_gemini } = req.body;
   const updates: any = {};
   if (config_chat_model !== undefined) updates.config_chat_model = config_chat_model;
   if (config_whisper_model !== undefined) updates.config_whisper_model = config_whisper_model;
   if (config_system_prompt !== undefined) updates.config_system_prompt = config_system_prompt;
   if (config_report_json_schema !== undefined) updates.config_report_json_schema = config_report_json_schema;
+  if (use_gemini !== undefined) updates.use_gemini = use_gemini;
 
   // Fetch the single master_config row ID to use in WHERE clause
   const { data: existing, error: idError } = await supabase


### PR DESCRIPTION
## Summary
- Add Google Gemini API as an alternative to OpenAI for report generation
- Use gemini-2.5-flash model as specified
- Configurable via use_gemini setting in master_config table

## Changes Made
- **New gemini-service.ts**: Implements Gemini API integration using @google/genai package
- **Modified daily-report.ts**: Added conditional logic to use either OpenAI or Gemini based on config
- **Updated config routes**: Added use_gemini field to master-config endpoint
- **Switched to master_config**: Now uses master_config table instead of subscription-based config for consistency

## Configuration
- GEMINI_API_KEY environment variable (already set in Railway)
- use_gemini boolean field in master_config table controls which API to use
- Defaults to OpenAI (false) for backward compatibility

## Test plan
- [ ] Verify master_config table has use_gemini column
- [ ] Test report generation with use_gemini=false (OpenAI)
- [ ] Test report generation with use_gemini=true (Gemini)
- [ ] Verify config endpoint accepts use_gemini parameter

🤖 Generated with [Claude Code](https://claude.ai/code)